### PR TITLE
Add inline docs on zsh alternatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,17 @@ sudo bash --login -c 'rvm use 2.4.1; chef-solo -c /opt/chef/cookbooks/developmen
   - `bash/` - shell examples and SSH helpers.
   - `bin/` - custom command line utilities and prototype scripts.
   - `cheatsheets/` - quick reference guides for tools (git, tmux, etc.).
-  - `custom/` - personal cheat entries consumed by the `cheat` utility.
+  - `custom/` - personal cheat entries for the `cheat` or `navi` utilities,
+    letting you fuzzy find frequently used commands.
   - `docs/` - assorted documentation like logs and setup notes.
   - `etc/` - sample configuration files such as `knife.rb.example`.
   - `notes/` - topic-specific notes (cron, virtualbox, etc.).
   - `pseudocode/` - design notes and planning snippets.
-  - `tmux/`, `vim/`, `zsh/` - configuration directories for these tools.
+  - `tmux/`, `vim/`, `zsh/` - configuration directories for these tools. The
+    `zsh` folder includes an oh-my-zsh setup. Most custom helpers live in
+    `functions.zsh`, which now replaces many older aliases. Over time,
+    commands from `files/custom` can be searched with `navi`, making even the
+    functions themselves optional (see `zsh/README.md`).
   - `unix.example.0` and `matches` - example command snippets.
 - `recipes/` - main Chef recipes to configure different platforms.
 - `templates/` - template files for configuration (e.g. `zshrc.erb`).

--- a/files/zsh/README.md
+++ b/files/zsh/README.md
@@ -1,0 +1,18 @@
+# zsh configuration
+
+This directory contains a modular zsh setup used by the cookbook.
+
+- **zshrc** – top level file that loads the rest of the configuration.
+- **oh-my-zsh.zsh** – bootstraps oh-my-zsh with the `powerlevel9k` theme and enables the `git` and `fzf` plugins.
+- **aliases.zsh** – large collection of aliases for git, editing and system tasks.
+- **functions.zsh** – custom helper functions and fzf based utilities.
+- **variables.zsh** – environment variables such as `$DEVSETUP` and `$ARCHIVE`.
+- **history.zsh** – settings for history sharing and size.
+- **numpad.zsh** – key bindings for numeric keypad usage.
+
+`functions.zsh` contains the main custom helpers and makes many entries in
+`aliases.zsh` redundant.  Most helpers rely on `fzf` for interactive selection.
+Over time the cheat sheets under `../custom` can be used with the `navi` tool,
+making these functions optional.
+
+The recipe `recipes/zsh.rb` installs oh-my-zsh and links `~/.zshrc` to this configuration.

--- a/files/zsh/aliases.zsh
+++ b/files/zsh/aliases.zsh
@@ -1,5 +1,10 @@
 # Bookmarks:
 # frequentuse, updatedaily
+#
+# Many of these aliases are now superseded by functions or plugins.
+# The oh-my-zsh `git` plugin offers shortcuts such as `gst` for `git status`.
+# You can also store command snippets in `navi` cheat sheets, e.g.:
+#   `navi --query "rsync"`
 
 g='git'
 

--- a/files/zsh/functions.zsh
+++ b/files/zsh/functions.zsh
@@ -1,6 +1,14 @@
-# conventions 
+# conventions
 # <context>-<object>-<verb>
 # shell-vbox-list
+#
+# Many helpers in this file wrap basic tooling. You can often rely on
+# dedicated utilities instead:
+#   - `navi` to recall commands from cheat sheets. Example:
+#       `navi --query "git log"`
+#   - `zoxide` for directory jumping. Example:
+#       `zoxide add ~/projects/myapp` then `z myapp`
+#   - The oh-my-zsh `git` plugin provides aliases such as `gdiff`.
 
 
 #

--- a/files/zsh/oh-my-zsh.zsh
+++ b/files/zsh/oh-my-zsh.zsh
@@ -44,5 +44,7 @@ ZSH_THEME="powerlevel9k/powerlevel9k"
 # Example format: plugins=(rails git textmate ruby lighthouse)
 # Add wisely, as too many plugins slow down shell startup.
 plugins=(git fzf)
+# The git plugin supplies aliases such as `gst` (git status) and `gdiff`.
+# The fzf plugin adds fuzzy search widgets (CTRL-T, CTRL-R).
 
 source $ZSH/oh-my-zsh.sh

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -1,4 +1,8 @@
 export TERM="xterm-256color" #WARNING! Your terminal appears to support fewer than 256 colors!
+# Additional helpers:
+#   - `zoxide` improves directory navigation. Example:
+#       `zoxide add ~/workspace/project` then `z project`
+#   - `navi` shows commands from cheat sheets with `navi --query <search>`
 
 
 INCLUDE=/opt/chef/cookbooks/development-setup/files/zsh


### PR DESCRIPTION
## Summary
- document external alternatives in `functions.zsh`
- explain in `aliases.zsh` that many shortcuts can come from plugins or `navi`
- note `zoxide` and `navi` usage in `zshrc`
- describe what the `git` and `fzf` plugins provide inside `oh-my-zsh.zsh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685397caaa90832680fa2ad95a025049