### PR TITLE
Move simple helper functions to navi cheats

### DIFF
--- a/files/custom/advanced_git.cheat
+++ b/files/custom/advanced_git.cheat
@@ -29,6 +29,8 @@
 
 # Branching - Switch to an existing branch named $FP
     git switch $FP
+# Branching - Backup current branch with date suffix
+    git checkout -b $(git branch --show-current)-backup_$(date +'%m-%d-%Y')
 
 # Committing Changes - Stage a file for commit
     git add $FP
@@ -137,6 +139,8 @@
 
 # Logging and History - Show a concise commit history
     git log --oneline --graph
+# Logging and History - List merge commits with dates
+    git log --merges --pretty=format:"%H %ad %s" --date=short
 
 # Logging and History - Show commit history with file changes
     git log --stat
@@ -149,6 +153,9 @@
 
 # Logging and History - Show reference log (actions affecting HEAD)
     git reflog
+
+# Logging and History - Show diffs for a specific file
+    git log -p -- $FP
 
 # Diffing and Comparing - Show unstaged changes
     git diff
@@ -167,6 +174,12 @@
 
 # Diffing and Comparing - Summarize changes against main for the current branch
     git diff --stat main $(git branch --show-current)
+# Diffing and Comparing - Compare current branch to main
+    git diff main $(git branch --show-current)
+# Diffing and Comparing - Compare current branch to master
+    git diff master $(git branch --show-current)
+# Diffing and Comparing - Summarize differences with master
+    git diff --stat master $(git branch --show-current)
 
 # Submodules - Add a submodule to the repository
     git submodule add $FP

--- a/files/custom/advanced_vim.cheat
+++ b/files/custom/advanced_vim.cheat
@@ -10,6 +10,8 @@
 
 # File Operations - Open file in read-only mode
     vim -R $FP
+# File Operations - Edit a new temporary file
+    vim $(mktemp)
 
 # File Operations - Open two files side by side in vertical splits
     vim -O $FP $FP2

--- a/files/custom/brad_reminder.cheat
+++ b/files/custom/brad_reminder.cheat
@@ -23,3 +23,9 @@
     python3 manage.py migrate database 0040_file_name_handling
 # Create symlink to server_api
     ln -sf /opt/vmass/server_api
+
+# Disk usage summary sorted by size
+    du -ch * | sort -h
+
+# List available Makefile targets
+    make -pRrq -f Makefile | awk -F: '/^[a-zA-Z0-9][^$#\\t=]*:([^=]|$)/ {print $1}' | sort | uniq

--- a/files/zsh/functions.zsh
+++ b/files/zsh/functions.zsh
@@ -111,9 +111,6 @@ tmux-options() {
   man tmux | grep -iE '(key bindings are|rename)'
 }
 
-function du-ch () {
-  du -ch * | sort -h
-}
 
 cdd () {
   echo "Use cd Ctrl-t instead"
@@ -331,32 +328,6 @@ arc() {
 # Section: git functions
 #
 
-git-list-merges() {
-  git log --merges --pretty=format:"%H %ad %s" --date=short
-}
-
-git-backup-branch() {
-  git checkout -b $(git branch --show-current)-backup_$(date +'%m-%d-%Y')
-}
-
-# moved to navi cheat: advanced_git
-# git diff --stat main $(git branch --show-current)
-
-git-diff-main() {
-  git diff main $(git branch --show-current)
-}
-
-git-diff-master-summarize() {
-  git diff --stat master $(git branch --show-current)
-}
-
-git-diff-master() {
-  git diff master $(git branch --show-current)
-}
-
-git-show-file-diffs() {
-  git log -p -- "$1"
-}
 
 git-branch() {
   git checkout -b "$1"
@@ -421,9 +392,6 @@ gcof() {
 # Section: build utilities
 #
 
-make-list-targets() {
-  make -pRrq -f Makefile | awk -F: '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {print $1}' | sort | uniq
-}
 
 #
 #
@@ -438,13 +406,6 @@ make-list-targets() {
 # Section: editor shortcuts vim
 #
 
-vtmp() {
-  vim $(mktemp)
-}
-
-vim-tmp() {
-  vim $(mktemp)
-}
 
 # neat, but use :Tags from fzf.vim 
 vim-goto() {


### PR DESCRIPTION
## Summary
- drop one-liner helpers from `functions.zsh`
- record git helpers in `advanced_git.cheat`
- add a temp file helper to `advanced_vim.cheat`
- keep quick tips for disk usage and make targets in `brad_reminder.cheat`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685428bb69fc8326923ca78857189248