### PR TITLE
Refactor helper commands into navi cheats

### DIFF
--- a/files/.command_palettes/to_try.txt
+++ b/files/.command_palettes/to_try.txt
@@ -3,13 +3,13 @@ exa # Modern replacement for ls with better formatting and git integration. SELE
 
 # <Vim Usage>
 vim-usage # Show Vim usage patterns and commands. SELECTME
-vim-goto # Hop to a pattern within Vim. SELECTME
+vim -c "/pattern" -c "normal zt" "$(rg -l pattern | head -n1)" # Hop to a pattern within Vim. SELECTME
 
 # <System Monitoring and Logs>
 last [reboot] # Show system reboots and user login history. SELECTME
 
 # <Clipboard and Text Management>
-arc scratch.txt # Store arbitrary terminal captures in "reports" to keep clipboard clean. SELECTME
+mv scratch.txt "scratch.txt-archived-$(date +%Y%m%d%H%M).txt" && touch scratch.txt # Store arbitrary terminal captures in "reports" to keep clipboard clean. SELECTME
 
 # <File Search and Filtering>
 rg -tsh -e "todo" -trb -e "function" -tjava -e "System.out.print" # Search using file type filtering. SELECTME

--- a/files/custom/advanced_vim.cheat
+++ b/files/custom/advanced_vim.cheat
@@ -58,6 +58,15 @@
 # Search and Navigation - Open file with line wrapping disabled
     vim +':set nowrap' $FP
 
+# Search and Navigation - Open first matching file for 'pattern'
+    vim -c "/pattern" -c "normal zt" "$(rg -l pattern | head -n1)"
+
+# Search and Navigation - Edit a file modified in git
+    vim "$(git status --short | awk '{print $2}' | fzf)"
+
+# Search and Navigation - Edit files changed from master
+    git diff $(git branch --show-current) master --name-only > /tmp/asdf && vim $(cat /tmp/asdf | fzf)
+
 # Multi-file Editing - Open multiple files in separate tabs
     vim -p $FP $FP2 $FP3
 

--- a/files/custom/brad_try_next.cheat
+++ b/files/custom/brad_try_next.cheat
@@ -11,7 +11,7 @@
 
 # Show Vim patterns and navigation
     vim-usage
-    vim-goto
+    vim -c "/pattern" -c "normal zt" "$(rg -l pattern | head -n1)"
 
 # Column Formatting - Adjust text alignment
     column
@@ -27,7 +27,7 @@
     last [reboot]
 
 # Clipboard Management - Store temporary terminal captures
-    arc scratch.txt
+    mv scratch.txt "scratch.txt-archived-$(date +%Y%m%d%H%M).txt" && touch scratch.txt
 
 # File Search - Search with type filtering
     rg -tsh -e "todo" -trb -e "function" -tjava -e "System.out.print"

--- a/files/custom/brad_utilities.cheat
+++ b/files/custom/brad_utilities.cheat
@@ -71,3 +71,9 @@
 # Checkout branch from stored list
     git checkout $(cat /var/brad/lists/branches.list | fzf)
 
+# Check if the current shell was launched from ranger
+    ps aux | grep "$PPID" | grep -qa ranger && echo "You are in ranger" || echo "not in ranger"
+
+# Archive a file with a timestamped name then recreate an empty file
+    mv $FP "${FP}-archived-$(date +%Y%m%d%H%M).txt" && touch $FP
+

--- a/files/zsh/functions.zsh
+++ b/files/zsh/functions.zsh
@@ -121,9 +121,6 @@ function start_long_running_process {
     echo $! > ~/background_jobs/${job_name}_pid.txt
 }
 
-am_I_in_ranger() {
-  ps aux | grep "$PPID" | grep -qa ranger && echo "You are in ranger" || echo "not in ranger"
-}
 
 # Problem: using Ctrl-R to search for a file open in vim does not work
 # unless absolute filepaths are used.  Solution:
@@ -265,10 +262,6 @@ cfc () {
 #  batcat
 #}
 
-archive() {
-  # consider prompting for archive reason, tack onto beginning of file
-  mv "$1" "$ARCHIVE"
-}
 
 # More commands
 # echo '    pstree $(pgrep -f postinstall | head -n1)'
@@ -277,40 +270,12 @@ archive() {
 
 
 #archive_file() {
-arc() {
-    local source_file="$1"
-    if [[ ! -f "$source_file" ]]; then
-        echo "Error: $source_file does not exist or is not a regular file."
-        return 1
-    fi
-    
-    local timestamp="$(date +%Y%m%d%H%M)"
-    local renamed_filename="${source_file}-archived-${timestamp}.txt"
-    
-    mv "$source_file" "$renamed_filename"
-    touch "$source_file"
-    
-    echo "File archived as ${renamed_filename}"
-}
 
 # Section: editor shortcuts vim
 #
 
 
 # neat, but use :Tags from fzf.vim 
-vim-goto() {
-  local pattern="$1"
-  vim -c "/$pattern" -c "normal zt" "$(rg -l $pattern | head -n1)"
-}
-
-vim-files-changed-in-branch() {
-  git diff $(git branch --show-current) master --name-only > /tmp/asdf
-  vim $(cat /tmp/asdf | fzf)
-}
-
-vim-files-modified () {
-  vim "$(git status --short | awk "{print \$2}" | fzf)"
-}
 
 prompt-clipboard() {
   if ! [[ -e ~/Documents/txt/var/.clipboard.swp ]] ; then


### PR DESCRIPTION
## Summary
- drop a few simple helper functions from `functions.zsh`
- record shell/ranger check and archive helper in `brad_utilities.cheat`
- capture vim helper commands in `advanced_vim.cheat`
- inline commands instead of functions in `brad_try_next.cheat`
- update command palettes

## Testing
- `bash -n run.sh`

------
https://chatgpt.com/codex/tasks/task_b_685436fcffac83268a66aef2c065c5a2