### PR TITLE
Fix theme loading order in zshrc

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -18,7 +18,6 @@ source $INCLUDE/oh-my-zsh.zsh
 source $INCLUDE/sources.zsh
 
 #ZSH_THEME="robbyrussell"
-ZSH_THEME="random"
 
 
 source /usr/share/autojump/autojump.sh


### PR DESCRIPTION
## Summary
- ensure only one theme is set before Oh My Zsh loads by removing the redundant `ZSH_THEME="random"` line

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68555bb8ad808326a4c9b4cbe46524c5