### PR TITLE
Restore git-branch-hop from history

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ sudo bash --login -c 'rvm use 2.4.1; chef-solo -c /opt/chef/cookbooks/developmen
 - `attributes/` - default configuration attributes for the cookbook.
 - `files/` - various helper scripts, notes and configuration files used by the cookbook:
   - `bash/` - shell examples and SSH helpers.
-  - `bin/` - custom command line utilities and prototype scripts.
+  - `bin/` - custom command line utilities and prototype scripts. The
+      `git-branch-hop` utility (requires `fzf`) lets you switch to a recent branch via fuzzy search. Two
+      zsh functions `git-branch-hop` and `git-branch-hop-old` provide the same
+      idea with different implementations for easy comparison.
   - `cheatsheets/` - quick reference guides for tools (git, tmux, etc.).
   - `custom/` - personal cheat entries for the `cheat` or `navi` utilities,
     letting you fuzzy find frequently used commands.

--- a/files/bin/git-branch-hop
+++ b/files/bin/git-branch-hop
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Fuzzy checkout of recently used git branches.
+
+set -e
+
+branch=$(git reflog | grep -o 'moving from.*' | head -n25 \
+  | sed 's/moving //; s/from //; s/to //' \
+  | xargs -n 1 | sort | uniq | fzf)
+
+if [ -n "$branch" ]; then
+  git checkout "$branch"
+fi

--- a/files/zsh/fn_git.zsh
+++ b/files/zsh/fn_git.zsh
@@ -1,0 +1,21 @@
+# git helper functions
+
+# Legacy version that wrote selection to a temp file
+# for later `git checkout`. Provided for comparison.
+git-branch-hop-old() {
+  git reflog | grep -o 'moving from.*' | head -n25 \
+    | sed 's/moving //; s/from //; s/to //' \
+    | xargs -n 1 | sort | uniq | fzf > /var/brad/tmp/branch
+  git checkout "$(cat /var/brad/tmp/branch)"
+}
+
+# Modern approach using a shell variable
+# and skipping the intermediate temp file
+# Requires `fzf` for selection
+git-branch-hop() {
+  local branch
+  branch=$(git reflog | grep -o 'moving from.*' | head -n25 \
+    | sed 's/moving //; s/from //; s/to //' \
+    | xargs -n 1 | sort | uniq | fzf)
+  [[ -n $branch ]] && git checkout "$branch"
+}

--- a/files/zsh/functions.zsh
+++ b/files/zsh/functions.zsh
@@ -8,3 +8,4 @@ source $_dir/fn_core.zsh
 source $_dir/fn_file.zsh
 source $_dir/fn_shortcuts.zsh
 source $_dir/fn_login.zsh
+source $_dir/fn_git.zsh


### PR DESCRIPTION
## Summary
- add a `git-branch-hop` helper to `files/bin`
- document the helper in `README`
- add git-branch-hop functions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_68595dd76f9c8326b424807d05c52d7b