### PR TITLE
Add log summary to shell-status jobs

### DIFF
--- a/files/zsh/fn_login.zsh
+++ b/files/zsh/fn_login.zsh
@@ -157,8 +157,21 @@ shell-status-jobs() {
       wait $pid
     done
 
+    shell-status-jobs-summary
+
     shell-notify "Shell status background jobs complete"
   } &
+}
+
+shell-status-jobs-summary() {
+  for log in "$jobsd"/*.log(N); do
+    if [[ -f "$log" ]]; then
+      local count=$(wc -l < "$log")
+      echo "---- $(basename "$log") ($count lines) ----"
+      head "$log"
+      echo
+    fi
+  done
 }
 
 


### PR DESCRIPTION
## Summary
- show `head` and line counts of shell status job logs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685d4d5854108326ba8ed828d77c1cdb