### PR TITLE
feat: track terminal tooling changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2025-09-03
+- Add root-level changelog and login news integration.
+- Introduce tools/recent-changes script to surface git log for files/bin and files/zsh.

--- a/files/zsh/fn_login.zsh
+++ b/files/zsh/fn_login.zsh
@@ -35,26 +35,30 @@ shell_login_overview() {
 
 show_news() {
   local stamp_file="$PERSONAL_DIR/news_timestamp"
-  local news_file
+  local changelog="$DEVSETUP/CHANGELOG.md"
 
-  if [[ -f "$DEVSETUP/files/zsh/NEWS.md" ]]; then
-    news_file="$DEVSETUP/files/zsh/NEWS.md"
-  elif [[ -f "$DEVSETUP/files/custom/brad_discoverability.cheat" ]]; then
-    news_file="$DEVSETUP/files/custom/brad_discoverability.cheat"
-  else
-    return
-  fi
+  [[ -f "$changelog" ]] || return
 
-  local now=$(date +%s)
   local last=0
   [[ -f "$stamp_file" ]] && last=$(date -r "$stamp_file" +%s)
 
-  if (( now - last > 86400 )); then
+  local updates
+  updates=$(awk -v last="$last" '
+    /^## / {
+      split($2, d, "-");
+      t = mktime(d[1] " " d[2] " " d[3] " 00 00 00");
+      show = (t > last)
+    }
+    show { print }
+  ' "$changelog")
+
+  if [[ -n "$updates" ]]; then
     echo '---- News ----'
-    tail -n 5 "$news_file"
+    echo "$updates"
     echo '--------------'
-    touch "$stamp_file"
   fi
+
+  touch "$stamp_file"
 }
 
 shell-status() {

--- a/tools/recent-changes
+++ b/tools/recent-changes
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Show recent git changes for terminal tooling directories.
+# Usage: tools/recent-changes [git log options]
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [[ -z "$repo_root" ]]; then
+  echo "Not inside a git repository" >&2
+  exit 1
+fi
+
+cd "$repo_root" || exit 1
+
+git log --oneline -- files/bin files/zsh "$@"


### PR DESCRIPTION
## Summary
- track terminal tooling updates in new CHANGELOG
- show changelog entries on login with show_news
- provide tools/recent-changes to view git history for files/bin and files/zsh

## Testing
- `source files/zsh/fn_login.zsh && show_news`
- `tools/recent-changes | head`


------
https://chatgpt.com/codex/tasks/task_e_68b87f659c2483328d892e3f6c4062e1