### PR TITLE
Improve search_files helper with ripgrep support

### DIFF
--- a/files/zsh/README.md
+++ b/files/zsh/README.md
@@ -16,6 +16,11 @@ This directory contains a modular zsh setup used by the cookbook.
 Over time the cheat sheets under `../custom` can be used with the `navi` tool,
 making these functions optional.
 
+Several helpers call out to external search tools. The `search_files` crawler
+prefers [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`) when available
+for faster traversal of the reports directory, but it still falls back to the
+standard `grep` implementation if `rg` is not installed.
+
 The recipe `recipes/zsh.rb` installs oh-my-zsh and links `~/.zshrc` to this configuration.
 
 ## Design notes


### PR DESCRIPTION
## Summary
- update `search_files` to batch keywords and prefer ripgrep when it is installed while keeping the grep fallback
- pass the ignored directory list through `crawl_keywords`/`do_crawl` so the ripgrep call receives the same exclusions
- document the optional ripgrep speed-up for the zsh helpers

## Testing
- bash -lc 'export PERSONAL_DIR="/tmp/tmp.iIPN47haqb"; source files/zsh/fn_core.zsh; search_files "##todo" "##starred" -- _archived tmp'
- bash -lc 'export PERSONAL_DIR="/tmp/tmp.iIPN47haqb"; source files/zsh/fn_core.zsh; PATH=/bin; search_files "##todo" "##starred" -- _archived tmp'

------
https://chatgpt.com/codex/tasks/task_e_68ca26e9c9c48332876436ae3e434d1e