### PR TITLE
README: simplify Project Index, remove duplicate dashboard instructions, and consolidate files/ references

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ sudo bash --login -c 'rvm use 2.4.1; chef-solo -c /opt/chef/cookbooks/developmen
   and `bash scripts/ci-test.sh` from the repository root to mirror CI and Codex
   cloud automation. Start the dev server with `npm run dev -- --host 127.0.0.1 --port 4173`
   after the backend is running.
-- `ReactDashboard/` - React/Vite dashboard frontend. Run `npm ci`, `npm test`,
-  and `npm run build` inside this directory to mirror the local automation
-  workflow. Start the dev server with `npm run dev -- --host 127.0.0.1 --port 4173`
-  after the backend is running. The browser entrypoint redirects `/` to the
-  simpler shell-backed dashboard at `/simple`, while the richer prior view now
-  lives at `/full`.
 - `flaskdashboard/` - minimal Flask API backend for the dashboard. See
   `flaskdashboard/README.md` for the venv setup, test command, startup
   instructions, and available API routes.
@@ -42,26 +36,9 @@ sudo bash --login -c 'rvm use 2.4.1; chef-solo -c /opt/chef/cookbooks/developmen
 ### Chef cookbook
 
 - `attributes/` - default configuration attributes for the cookbook.
-- `files/` - various helper scripts, notes and configuration files used by the cookbook:
-  - `bash/` - shell examples and SSH helpers.
-  - `bin/` - custom command line utilities and prototype scripts. The
-      `git-branch-hop` utility (requires `fzf`) lets you switch to a recent branch via fuzzy search. Two
-      zsh functions `git-branch-hop` and `git-branch-hop-old` provide the same
-      idea with different implementations for easy comparison.
-  - `cheatsheets/` - quick reference guides for tools (git, tmux, etc.).
-  - `custom/` - personal cheat entries for the `cheat` or `navi` utilities,
-    letting you fuzzy find frequently used commands.
-  - `docs/` - assorted documentation like logs and setup notes.
-    See `docs/DECISIONS.md` for project choices.
-  - `etc/` - sample configuration files such as `knife.rb.example`.
-  - `notes/` - topic-specific notes (cron, virtualbox, etc.).
-  - `pseudocode/` - design notes and planning snippets.
-  - `tmux/`, `vim/`, `zsh/` - configuration directories for these tools. The
-    `zsh` folder includes an oh-my-zsh setup. Most custom helpers live in
-    `functions.zsh` sources several `fn_*.zsh` modules that replace many older aliases. Over time,
-    commands from `files/custom` can be searched with `navi`, making even the
-    functions themselves optional (see `zsh/README.md`).
-  - `unix.example.0` and `matches` - example command snippets.
+- `files/` - helper scripts, configuration, and notes used by the cookbook.
+  See `files/etc/README.md`, `files/docs/DECISIONS.md`, and `files/zsh/README.md`
+  for focused details.
 - `recipes/` - main Chef recipes to configure different platforms.
 - `templates/` - template files for configuration (e.g. `zshrc.erb`).
 - `tools/` - utility scripts such as Ruby analysis helpers.


### PR DESCRIPTION
### Motivation

- Clarify and simplify the repository README by removing duplicated instructions and reducing noisy, overly-detailed directory listings. 
- Make the `files/` section easier to scan by pointing readers to focused sub-README files instead of embedding a long list of items.

### Description

- Removed a duplicated `ReactDashboard/` instruction block and kept a single, clearer startup note for the dashboard and associated automation commands. 
- Condensed the `files/` directory documentation into a short, single-line summary and added explicit pointers to `files/etc/README.md`, `files/docs/DECISIONS.md`, and `files/zsh/README.md` for details. 
- Deleted several verbose sub-item entries and example snippets from the `files/` listing to improve readability. 
- Minor formatting and line cleanup in `README.md` to improve presentation.

### Testing

- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d4595ff6f48332a77d19f961ca8a19)