### PR TITLE
Add powersearch CLI with planner/executor and spec documents

### DIFF
--- a/ENGINEERING_SPEC.md
+++ b/ENGINEERING_SPEC.md
@@ -1,0 +1,129 @@
+# Executive Summary
+
+`powersearch` is a toy CLI that makes `find`, `grep`, and bash expansion easier to use without hiding how they work. This specification is the engineering source of truth for implementation constraints, component boundaries, and runtime safety.
+
+This document intentionally emphasizes **how** the software is built (ownership, process control, failure semantics, and observability), not only **what** user-facing features exist.
+
+Core engineering goals:
+
+1. Keep each entity single-purpose with explicit input/output contracts.
+2. Make entity wiring explicit and deterministic.
+3. Bound resource usage (process count, buffered output, execution time).
+4. Guarantee child-process lifecycle hygiene (no zombies, no runaway subprocess trees).
+5. Preserve transparency with reproducible command plans and structured diagnostics.
+
+# List of entities
+
+- **CLIAdapter**
+  - Concern starts: parsing argv into strongly validated options.
+  - Concern ends: emits immutable `SearchRequest` or validation errors.
+  - Forbidden concerns: shell construction, process execution.
+
+- **SearchRequest (value object)**
+  - Concern starts: represent normalized user intent.
+  - Concern ends: immutable data transfer between layers.
+  - Forbidden concerns: business decisions, side effects.
+
+- **Planner**
+  - Concern starts: convert `SearchRequest` into `ExecutionPlan`.
+  - Concern ends: returns declarative command graph + safety metadata.
+  - Forbidden concerns: launching processes, rendering user output.
+
+- **ExecutionPlan (value object)**
+  - Concern starts: encode one or more commands, pipelines, and limits.
+  - Concern ends: handoff contract for execution.
+  - Forbidden concerns: mutable runtime state.
+
+- **Executor**
+  - Concern starts: execute an `ExecutionPlan` with resource/time limits.
+  - Concern ends: emits `ExecutionResult` and guarantees process cleanup.
+  - Forbidden concerns: argument parsing, planning logic.
+
+- **OutputStreamer**
+  - Concern starts: stream stdout/stderr incrementally to avoid memory bloat.
+  - Concern ends: forwards bounded chunks/events to Presenter.
+  - Forbidden concerns: command semantics, retries.
+
+- **Presenter**
+  - Concern starts: render preview, logs, summaries, and user-facing errors.
+  - Concern ends: stable human-readable output format.
+  - Forbidden concerns: command mutation, subprocess lifecycle.
+
+- **TelemetrySink**
+  - Concern starts: collect structured events (start/stop/timeout/exit code).
+  - Concern ends: append-only diagnostics channel.
+  - Forbidden concerns: decision-making or control flow.
+
+- **ExitPolicy**
+  - Concern starts: map `ExecutionResult` + validation failures to exit codes.
+  - Concern ends: one final process exit status.
+  - Forbidden concerns: rendering or execution.
+
+# Tables
+
+## Table 1 — Entity Wiring & Call Order
+
+| Step | Caller | Callee | Data In | Data Out | Sync/Async | Failure Ownership |
+|---|---|---|---|---|---|---|
+| 1 | `main` | `CLIAdapter` | raw `argv` | `SearchRequest` or parse error | sync | `CLIAdapter` returns typed validation errors |
+| 2 | `main` | `Planner` | `SearchRequest` | `ExecutionPlan` | sync | `Planner` raises planning errors only |
+| 3 | `main` | `Presenter` | `ExecutionPlan` | preview text | sync | `Presenter` cannot fail closed; fallback plain text |
+| 4 | `main` | `Executor` | `ExecutionPlan` | `ExecutionResult` | async runtime, sync API | `Executor` owns child lifecycle + timeout handling |
+| 5 | `Executor` | `OutputStreamer` | subprocess pipes | output events | async | `OutputStreamer` owns bounded buffering |
+| 6 | `main` | `TelemetrySink` | lifecycle events | none | fire-and-forget | telemetry failures never break command flow |
+| 7 | `main` | `ExitPolicy` | parse/plan/exec result | integer exit code | sync | `ExitPolicy` is final arbiter |
+
+## Table 2 — Boundary Contracts (What Each Entity Must Not Do)
+
+| Entity | Allowed Responsibilities | Explicitly Out of Scope |
+|---|---|---|
+| `CLIAdapter` | parse flags, enforce required args, normalize defaults | building shell strings, spawning processes |
+| `Planner` | create deterministic command graph, attach safety limits | reading process output, formatting terminal logs |
+| `Executor` | spawn process group, enforce timeout, terminate descendants, collect status | reinterpreting business intent, changing plan at runtime |
+| `OutputStreamer` | non-blocking reads, chunking, backpressure-aware forwarding | whole-output accumulation in memory |
+| `Presenter` | human-readable lines, preview blocks, concise diagnostics | decision logic for retries/timeouts |
+| `TelemetrySink` | append structured events with timestamps | user-facing display formatting |
+| `ExitPolicy` | stable mapping to exit codes | any side effects |
+
+## Table 3 — Runtime Safety & Resource Controls
+
+| Control | Owner | Default | Hard Limit | Enforcement Point |
+|---|---|---|---|---|
+| Max wall time per execution | `Executor` | 30s | 300s | kill process group on timeout |
+| Max concurrent subprocess groups | `Executor` | 1 | 1 | reject additional execution attempts |
+| Max buffered bytes per stream | `OutputStreamer` | 64 KiB | 1 MiB | ring buffer + truncation marker |
+| Max emitted lines | `OutputStreamer` + `Presenter` | 10,000 | 100,000 | stop streaming + emit overflow event |
+| Max command length | `Planner` | 8 KiB | 32 KiB | pre-exec validation failure |
+| Allowed shell executable | `Planner`/`Executor` | `/bin/bash` | fixed allowlist only | reject unsupported shells |
+
+## Table 4 — Process Lifecycle Guarantees
+
+| Lifecycle Phase | Required Behavior | Failure Fallback | Verifiable Signal |
+|---|---|---|---|
+| Spawn | start child in isolated process group | return startup error, no partial state | `process_started(pid, pgid)` event |
+| Stream | drain stdout/stderr without blocking main loop | truncate + continue with warning | `stream_chunk(channel, size)` events |
+| Timeout | send TERM to process group, wait grace period | escalate to KILL after grace window | `timeout`, `term_sent`, `kill_sent` events |
+| Normal exit | collect exit code and rusage where available | report partial metrics if unavailable | `process_exited(code, duration_ms)` |
+| Abnormal exit | capture signal/exception details | map to non-zero exit via `ExitPolicy` | `process_failed(reason)` |
+| Cleanup | always reap child processes | best-effort reap loop with warning | `cleanup_complete(reaped_count)` |
+
+## Table 5 — Failure Taxonomy & Exit Mapping
+
+| Failure Class | Origin Entity | User Message Style | Exit Code |
+|---|---|---|---|
+| ValidationError | `CLIAdapter` | concise actionable flag guidance | 2 |
+| PlanningError | `Planner` | unsupported combination + remediation hint | 2 |
+| TimeoutError | `Executor` | includes configured timeout and command id | 124 |
+| ResourceLimitError | `OutputStreamer`/`Executor` | limit exceeded + which limit | 125 |
+| SubprocessError | `Executor` | show child exit code/signal | propagate child or 1 |
+| InternalError | any entity | opaque-safe summary + event id | 1 |
+
+## Table 6 — Determinism & Testability Requirements
+
+| Requirement | Mechanism | Owner | Acceptance Check |
+|---|---|---|---|
+| Plan determinism | same input yields byte-identical `ExecutionPlan` | `Planner` | snapshot tests on plan serialization |
+| Side-effect isolation | pure parse/plan layers | `CLIAdapter`/`Planner` | unit tests with no subprocess creation |
+| Bounded memory | stream, never full-capture | `OutputStreamer` | stress test with very large stdout |
+| No zombie processes | guaranteed wait/reap paths | `Executor` | integration test inspects child state post-exit |
+| Stable exits | centralized mapping table | `ExitPolicy` | table-driven tests for all failure classes |

--- a/FEATURE_SPEC.md
+++ b/FEATURE_SPEC.md
@@ -1,0 +1,83 @@
+# Executive Summary
+
+`powersearch` is a toy command-line utility that gives developers a friendlier interface over three highly productive shell primitives:
+
+- `find` for recursive file discovery
+- `grep` for content filtering
+- Bash glob/brace expansion for expressive target selection
+
+The utility focuses on usability, not replacing shell tooling. It translates intuitive CLI flags into concrete shell commands, previews what will run, and executes through `bash -lc` so standard shell expansions work as users expect.
+
+Primary outcomes:
+
+1. Reduce memorization burden for common `find | grep` flows.
+2. Preserve transparency by showing the generated commands.
+3. Keep architecture minimal so the tool can be extended later.
+
+# List of entities
+
+- **PowerSearchCLI**: top-level argument parser and command router.
+- **SearchRequest**: normalized request object derived from CLI inputs.
+- **ShellCommandPlan**: ordered shell command strings produced from a request.
+- **CommandBuilder**: logic that maps request fields to `find`, `grep`, and expansion-aware bash snippets.
+- **CommandExecutor**: runs planned commands (`bash -lc`) and streams output.
+- **PreviewFormatter**: renders dry-run/preview output for developer trust.
+- **ExitStatusPolicy**: maps subprocess outcomes to CLI exit codes.
+
+# Tables
+
+## Table 1 — Command Surface
+
+| Command | Purpose | Core Inputs | Output | Notes |
+|---|---|---|---|---|
+| `scan` | File discovery using `find` wrappers | roots, name pattern, type, max depth | matching paths | supports multiple roots and simple defaults |
+| `match` | Content search via `grep` wrappers | pattern, path selectors, case mode, context lines | matching lines | can operate on explicit paths or expansion results |
+| `combo` | Compose discovery + content filtering | find filters + grep pattern | matching lines from matched files | equivalent to common `find ... -print0 | xargs -0 grep ...` flows |
+| `preview` | Show generated shell command without execution | any command inputs | rendered command string(s) | aids learning and trust |
+
+## Table 2 — `SearchRequest` Schema
+
+| Field | Type | Required | Example | Description |
+|---|---|---|---|---|
+| `mode` | enum(`scan`,`match`,`combo`,`preview`) | yes | `combo` | selected workflow |
+| `roots` | list[str] | no | `['src', 'tests']` | search roots; defaults to current directory |
+| `name_glob` | str | no | `"*.py"` | file name filter passed to `find -name` |
+| `path_expr` | str | no | `"**/*.md"` | bash-expansion path expression (evaluated in shell) |
+| `file_type` | enum(`f`,`d`) | no | `f` | `find -type` restriction |
+| `max_depth` | int | no | `4` | `find -maxdepth` |
+| `grep_pattern` | str | conditional | `"TODO|FIXME"` | regex/text pattern for grep-dependent modes |
+| `ignore_case` | bool | no | `true` | maps to `grep -i` |
+| `context_lines` | int | no | `2` | maps to `grep -C` |
+| `dry_run` | bool | no | `true` | preview only; do not execute |
+
+## Table 3 — Translation Rules (CLI → Shell)
+
+| Rule ID | Condition | Translation | Example |
+|---|---|---|---|
+| TR-01 | `mode=scan` with `name_glob` | build `find <roots> -name '<glob>'` | `find src -name '*.py'` |
+| TR-02 | `file_type` provided | append `-type` predicate | `find . -type f` |
+| TR-03 | `max_depth` provided | append `-maxdepth N` near root segment | `find . -maxdepth 3 -name '*.md'` |
+| TR-04 | `mode=match` + `path_expr` | expand via `bash -lc` then run `grep` over expanded paths | `grep -n 'foo' **/*.py` |
+| TR-05 | `ignore_case=true` | add `grep -i` | `grep -ni 'foo' file.txt` |
+| TR-06 | `context_lines>0` | add `grep -C <n>` | `grep -n -C 2 'foo' app.log` |
+| TR-07 | `mode=combo` | produce safe two-step pipeline (`find ... -print0` + `xargs -0 grep`) | `find . -name '*.py' -print0 \| xargs -0 grep -n 'foo'` |
+| TR-08 | `dry_run=true` or `mode=preview` | render command(s) only | prints generated shell without exec |
+
+## Table 4 — Error and Exit Behavior
+
+| Scenario | Detection | User Message | Exit Code |
+|---|---|---|---|
+| missing grep pattern in `match/combo` | argument validation | `--pattern is required for this mode` | 2 |
+| invalid depth (<0) | argument validation | `--max-depth must be >= 0` | 2 |
+| shell command failure | subprocess return code != 0 | show failed command and code | propagate subprocess code |
+| no results found | successful run with empty output | `No matches found` (optional) | 0 |
+| internal planner error | exception during build | concise diagnostic | 1 |
+
+## Table 5 — Non-Functional Requirements
+
+| Requirement | Target | Rationale |
+|---|---|---|
+| Transparency | always show runnable command in verbose/dry-run paths | builds trust and teaches shell usage |
+| Portability | assume POSIX shell with bash available | enables glob/brace expansion support |
+| Simplicity | single-file prototype acceptable | optimize for learning and iteration |
+| Extensibility | modular entity boundaries retained even in one file | future growth (extra filters, exclude rules) |

--- a/powersearch/main.py
+++ b/powersearch/main.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+"""Toy CLI wrapper over find/grep/bash expansion workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import selectors
+import shlex
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import List
+
+DEFAULT_TIMEOUT_SECONDS = 30
+HARD_TIMEOUT_SECONDS = 300
+DEFAULT_MAX_OUTPUT_BYTES = 64 * 1024
+HARD_MAX_OUTPUT_BYTES = 1024 * 1024
+DEFAULT_MAX_OUTPUT_LINES = 10_000
+HARD_MAX_OUTPUT_LINES = 100_000
+DEFAULT_MAX_COMMAND_LENGTH = 8 * 1024
+HARD_MAX_COMMAND_LENGTH = 32 * 1024
+SHELL_PATH = "/bin/bash"
+
+
+@dataclass(frozen=True)
+class SearchRequest:
+    mode: str
+    roots: List[str]
+    name_glob: str | None
+    path_expr: str | None
+    file_type: str | None
+    max_depth: int | None
+    pattern: str | None
+    ignore_case: bool
+    context: int
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class ExecutionPlan:
+    command: str
+    timeout_seconds: int = DEFAULT_TIMEOUT_SECONDS
+    max_output_bytes: int = DEFAULT_MAX_OUTPUT_BYTES
+    max_output_lines: int = DEFAULT_MAX_OUTPUT_LINES
+    max_command_length: int = DEFAULT_MAX_COMMAND_LENGTH
+    shell: str = SHELL_PATH
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    exit_code: int
+    timed_out: bool = False
+    resource_exhausted: bool = False
+    error_message: str | None = None
+
+
+class CLIAdapter:
+    @staticmethod
+    def parse_args() -> SearchRequest:
+        parser = argparse.ArgumentParser(
+            prog="powersearch",
+            description="Friendly wrapper around find, grep, and bash expansion",
+        )
+        parser.add_argument("mode", choices=["scan", "match", "combo", "preview"])
+        parser.add_argument("--roots", nargs="+", default=["."], help="Search roots")
+        parser.add_argument("--name", dest="name_glob", help="find -name pattern")
+        parser.add_argument("--path", dest="path_expr", help="Bash expansion path expression")
+        parser.add_argument("--type", dest="file_type", choices=["f", "d"], help="find -type")
+        parser.add_argument("--max-depth", type=int, help="find -maxdepth")
+        parser.add_argument("--pattern", help="grep pattern")
+        parser.add_argument("-i", "--ignore-case", action="store_true", help="grep -i")
+        parser.add_argument("-C", "--context", type=int, default=0, help="grep -C")
+        parser.add_argument("--dry-run", action="store_true", help="Print generated command only")
+
+        args = parser.parse_args()
+
+        if args.max_depth is not None and args.max_depth < 0:
+            raise ValueError("--max-depth must be >= 0")
+        if args.context < 0:
+            raise ValueError("--context must be >= 0")
+
+        return SearchRequest(
+            mode=args.mode,
+            roots=args.roots,
+            name_glob=args.name_glob,
+            path_expr=args.path_expr,
+            file_type=args.file_type,
+            max_depth=args.max_depth,
+            pattern=args.pattern,
+            ignore_case=args.ignore_case,
+            context=args.context,
+            dry_run=args.dry_run,
+        )
+
+
+class Planner:
+    @staticmethod
+    def _quote_many(values: List[str]) -> str:
+        return " ".join(shlex.quote(v) for v in values)
+
+    @staticmethod
+    def _effective_mode(req: SearchRequest) -> str:
+        if req.mode != "preview":
+            return req.mode
+        if req.pattern:
+            return "match" if req.path_expr else "combo"
+        return "scan"
+
+    @classmethod
+    def build_plan(cls, req: SearchRequest) -> ExecutionPlan:
+        find_parts = ["find", cls._quote_many(req.roots)]
+        if req.max_depth is not None:
+            find_parts.append(f"-maxdepth {req.max_depth}")
+        if req.file_type:
+            find_parts.append(f"-type {shlex.quote(req.file_type)}")
+        if req.name_glob:
+            find_parts.append(f"-name {shlex.quote(req.name_glob)}")
+
+        find_cmd = " ".join(find_parts)
+
+        grep_parts = ["grep", "-n"]
+        if req.ignore_case:
+            grep_parts.append("-i")
+        if req.context > 0:
+            grep_parts.extend(["-C", str(req.context)])
+        if req.pattern is not None:
+            grep_parts.append(shlex.quote(req.pattern))
+        grep_cmd = " ".join(grep_parts)
+
+        mode = cls._effective_mode(req)
+        if mode == "scan":
+            command = find_cmd
+        elif mode == "match":
+            if not req.pattern:
+                raise ValueError("--pattern is required for match mode")
+            target = req.path_expr or cls._quote_many(req.roots)
+            command = f"{grep_cmd} {target}"
+        elif mode == "combo":
+            if not req.pattern:
+                raise ValueError("--pattern is required for combo mode")
+            command = f"{find_cmd} -print0 | xargs -0 {grep_cmd}"
+        else:
+            raise ValueError(f"unsupported mode: {mode}")
+
+        if len(command) > HARD_MAX_COMMAND_LENGTH:
+            raise ValueError(f"command length exceeds hard limit ({HARD_MAX_COMMAND_LENGTH} bytes)")
+
+        return ExecutionPlan(command=command)
+
+
+class Executor:
+    @staticmethod
+    def _terminate_process_group(proc: subprocess.Popen[bytes], grace_seconds: float = 1.5) -> None:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+
+        deadline = time.monotonic() + grace_seconds
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                return
+            time.sleep(0.05)
+
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+
+    @classmethod
+    def run(cls, plan: ExecutionPlan) -> ExecutionResult:
+        timeout_seconds = min(plan.timeout_seconds, HARD_TIMEOUT_SECONDS)
+        max_output_bytes = min(plan.max_output_bytes, HARD_MAX_OUTPUT_BYTES)
+        max_output_lines = min(plan.max_output_lines, HARD_MAX_OUTPUT_LINES)
+
+        proc = subprocess.Popen(
+            [plan.shell, "-lc", plan.command],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+
+        selector = selectors.DefaultSelector()
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        selector.register(proc.stdout, selectors.EVENT_READ, sys.stdout.buffer)
+        selector.register(proc.stderr, selectors.EVENT_READ, sys.stderr.buffer)
+
+        total_bytes = 0
+        total_lines = 0
+        timed_out = False
+        resource_exhausted = False
+        start = time.monotonic()
+
+        try:
+            while selector.get_map():
+                if time.monotonic() - start > timeout_seconds:
+                    timed_out = True
+                    cls._terminate_process_group(proc)
+                    break
+
+                events = selector.select(timeout=0.2)
+                for key, _ in events:
+                    chunk = key.fileobj.read1(4096)
+                    if not chunk:
+                        selector.unregister(key.fileobj)
+                        continue
+
+                    total_bytes += len(chunk)
+                    total_lines += chunk.count(b"\n")
+                    key.data.write(chunk)
+                    key.data.flush()
+
+                    if total_bytes > max_output_bytes or total_lines > max_output_lines:
+                        resource_exhausted = True
+                        cls._terminate_process_group(proc)
+                        break
+
+                if resource_exhausted:
+                    break
+        finally:
+            selector.close()
+            proc.wait()
+
+        if timed_out:
+            return ExecutionResult(exit_code=124, timed_out=True, error_message="execution timed out")
+        if resource_exhausted:
+            return ExecutionResult(
+                exit_code=125,
+                resource_exhausted=True,
+                error_message="output limits exceeded",
+            )
+        return ExecutionResult(exit_code=proc.returncode)
+
+
+class Presenter:
+    @staticmethod
+    def show_plan(command: str) -> None:
+        print(f"[powersearch] {command}")
+
+    @staticmethod
+    def show_error(message: str) -> None:
+        print(message, file=sys.stderr)
+
+    @staticmethod
+    def show_no_matches() -> None:
+        print("No matches found")
+
+
+class ExitPolicy:
+    @staticmethod
+    def from_execution(result: ExecutionResult) -> int:
+        return result.exit_code
+
+
+def main() -> int:
+    try:
+        req = CLIAdapter.parse_args()
+        plan = Planner.build_plan(req)
+    except ValueError as exc:
+        Presenter.show_error(str(exc))
+        return 2
+
+    Presenter.show_plan(plan.command)
+
+    if req.dry_run or req.mode == "preview":
+        return 0
+
+    result = Executor.run(plan)
+    if result.error_message:
+        Presenter.show_error(result.error_message)
+    if result.exit_code == 1:
+        Presenter.show_no_matches()
+    return ExitPolicy.from_execution(result)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Provide a small, transparent CLI (`powersearch`) that composes `find`, `grep`, and bash expansion while making command generation explicit and safe.  
- Define clear engineering boundaries, resource limits, and deterministic wiring to reduce surprises from subprocess execution.  
- Ship a minimal, extensible implementation that can be iterated on and tested against the engineering and feature requirements.

### Description
- Add `powersearch/main.py`, a one-file implementation that includes `CLIAdapter`, `Planner`, `Executor`, `Presenter`, and `ExitPolicy` to parse requests, build shell command plans, execute them in isolated process groups, and render results.  
- Implement command translation rules for `scan`, `match`, `combo`, and `preview` modes with quoting and safety checks, and enforce hard limits on command length, timeouts, and output size.  
- Implement process lifecycle hygiene in `Executor` including process group creation, graceful `TERM` then `KILL` escalation, and bounded streaming with byte/line limits and truncation-triggered termination.  
- Add top-level documentation: `FEATURE_SPEC.md` describing user-facing behaviors and translation rules, and `ENGINEERING_SPEC.md` enumerating entity contracts, resource controls, failure taxonomy, and testability requirements.

### Testing
- No automated tests were added or executed as part of this change.  
- The `ENGINEERING_SPEC.md` includes recommended test targets (plan determinism, no-zombie integration tests, stream stress tests) to be implemented in follow-up work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc6869f2d08332bd37461f3eafd0af)