### PR TITLE
Add Codex local security handoff prompt and reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ sudo bash --login -c 'rvm use 2.4.1; chef-solo -c /opt/chef/cookbooks/developmen
 - `notes/dashboard-ui-components.md` - partial design document focused
   exclusively on the currently visible required UI components in the dashboard
   source code.
+- `prompt-examples/` - reusable handoff prompt snippets (including local Codex
+  security triage prompts); keyword status: **security** is pending follow-up
+  review.
 
 ### Standalone demos
 

--- a/prompt-examples/codex-local-security-handoff.md
+++ b/prompt-examples/codex-local-security-handoff.md
@@ -1,0 +1,71 @@
+# Codex Local Security Handoff Prompt
+
+Use this prompt when handing off local security triage work to another agent.
+
+```text
+You are taking over a security-triage session for this repository.  
+Assume many alerts are from stale, vestigial, demo, or placeholder content.
+
+## Operating style (important)
+- Work interactively with a human.
+- Discuss and decide one item at a time.
+- Keep each turn brief:
+  1) what the item is,  
+  2) whether it appears active or dead/archival,  
+  3) proposed action,  
+  4) ask for confirmation before moving on.
+- Do not batch decisions.
+- Prioritize reducing alert noise without hiding real risks.
+- Prefer evidence from repository files over assumptions.
+
+## Initial context already identified
+Potential alert sources include:
+
+1. Placeholder/credential-like strings in sample files  
+   - files/cheatsheets/gitlab.txt  
+   - files/bin/prototypes/exhibits/python/concept/start  
+   - files/bin/prototypes/exhibits/ruby/gem_elasticsearch.rb  
+   - node.json
+
+2. Legacy prototype command execution patterns (shell=True)  
+   - files/bin/prototypes/exhibits/python/concept/command.py  
+   - files/bin/prototypes/exhibits/python/concept/command_class.py
+
+3. Old vendored JS likely to trigger vulnerability scanners  
+   - files/bin/prototypes/sandbox/js/knockout/public/js/jquery-2.1.1.min.js  
+   - files/bin/prototypes/sandbox/js/knockout/public/js/knockout-2.3.0.js
+
+4. Active Flask app security posture concerns  
+   - flaskdashboard/app.py (debug=True, broad CORS, telemetry exposure)
+
+5. Unpinned Flask dependencies  
+   - flaskdashboard/requirements.txt
+
+## Workflow you must follow
+1. Start by asking the human which category to review first (or default to #1).  
+2. For the chosen item, inspect references/usage to determine if active or dead.  
+3. Provide a short recommendation with options:
+   - keep as-is,
+   - sanitize text,
+   - archive/exclude path,
+   - harden code,
+   - remove file.
+4. Wait for human decision.
+5. Apply only the approved change.
+6. Summarize outcome in 2–4 bullets, then propose the next single item.
+
+## Communication format for each item
+Use this exact structure each time:
+
+- Item: <path or alert>
+- Why flagged: <1 sentence>
+- Active or vestigial?: <evidence>
+- Recommended action: <one best action + one alternative>
+- Your decision?: <ask user to choose>
+
+## Goal
+Reach a clean, low-noise security signal by:
+- preserving truly useful examples,
+- isolating archival insecure code,
+- and hardening any actively used runtime paths.
+```


### PR DESCRIPTION
### Motivation
- Provide a reusable, structured prompt to hand off local security triage tasks to an agent. 
- Surface the new prompt in the repository index so reviewers can find and reuse it. 

### Description
- Add `prompt-examples/codex-local-security-handoff.md` containing an interactive handoff prompt with workflow, initial context, and communication format for stepwise security triage. 
- Update `README.md` to include the `prompt-examples/` entry and a brief note about the security triage prompt and its review status. 

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc2afed248833281e499fa943b2408)